### PR TITLE
Renew api user token after login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.1
+
+- Reset api user token after login
+
 ## 1.0.0
 
 - De- and encode data from secrets

--- a/ccli.gemspec
+++ b/ccli.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
     One of the main functionality is backing up secrets from cluster services (currently: openshift, kubernetes)
     to Cryptopus and restoring them as well.
   EOF
-  s.version       = '1.0.0'
+  s.version       = '1.0.1'
   s.summary       = 'Command line client for the opensource password manager Cryptopus'
   s.license       = 'MIT'
   s.homepage      = 'https://github.com/puzzle/ccli'

--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -27,6 +27,7 @@ class CLI
         token, url = extract_login_args(args)
         execute_action do
           session_adapter.update_session({ encoded_token: token, url: url })
+          renew_auth_token
 
           # Test authentification by calling teams endpoint
           Team.all
@@ -330,6 +331,10 @@ class CLI
 
   def k8s_adapter
     @k8s_adapter ||= K8SAdapter.new
+  end
+
+  def renew_auth_token
+    session_adapter.update_session({ token: cryptopus_adapter.renewed_auth_token })
   end
 end
 # rubocop:enable Metrics/ClassLength

--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -14,7 +14,7 @@ class CLI
   # rubocop:disable Metrics/MethodLength, Metrics/AbcSize, Metric/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/BlockLength
   def run
     program :name, 'cry - cryptopus cli'
-    program :version, '1.0.0'
+    program :version, '1.0.1'
     program :description, 'CLI tool to manage Openshift Secrets via Cryptopus'
     program :help, 'Source Code', 'https://www.github.com/puzzle/ccli'
     program :help, 'Usage', 'cry [flags]'


### PR DESCRIPTION
This reverts commit 824e82014b7ef2123eeec9dbfc5b1b4bce12c10f.

Problem is, Cryptopus is currently not able to renew an api user token via the api user himself. Merge this once this is possible