### PR TITLE
Add forwarding executable to reduce surprises

### DIFF
--- a/bin/ccli
+++ b/bin/ccli
@@ -1,0 +1,11 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+warn <<~MESSAGE
+  =========================================================================
+    The executable of this project is cry. I will invoke it now, but you
+    can skip this message if you just use "cry" from now on.
+  =========================================================================
+MESSAGE
+
+exec "cry #{ARGV.join(' ')}"


### PR DESCRIPTION
I was excited to try out this project. So I went ahead and installed the gem. I did this from the top of my head, just remembering it was the "ccli". The gem installed and my joy peaked. It was not extremly high, we are talking about a relatively mundane task I do all the time. The peak, only observable in hindsight, was there because it went downhill from there. I had the software (presumably), I had the dependencies (presumably), but `ccli` was a "Command not found" on my machine. I traded precious disk-space for a complete letdown. I was about to cry (well, not really, but bare with me). I researched* the Homepage of the Project for further guidance and landed directly on the repository. Little did I know that I was in for a ironic twist. Had I just given in to `cry`ing, maybe even `cry help`ing, I would have reached my goal. The way it went, I could only vaguely see the source-code through my teary eyes. I noticed that the gem is not named like the executable. I nodded and smiled at the bundler/bundle-reference and cried a tear of joy (on the inside, as I am a professional) at the real name of the executable.

This branch adds a simple, yet informative redirector for those who install the gem and try `ccli --help` instintively. I hereby humbly request that you pull this and integrate it into the codebase, for my personal benefit as well as your vast userbase.

N.B.: the indirector uses Features from 2.3, which is not consistent with the mininally required ruby-version of 2.0. Please let me know if I should address that shortcoming.

*) `gem info ccli`